### PR TITLE
Added keep_puncts option, which allows keeping punctuations in result

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ anh	yêu	em
 bún	chả	ở	nhà hàng	quán ăn	ngon	ko	ngon
 ```
 
+Whitespaces and punctuations are ignored during normal tokenization, but are kept during tokenization for transformation, which is used internally by Coc Coc search engine. To keep punctuations during normal tokenization, except those in segmented URLs, use `-k`. To run tokenization for transformation, use `-t` - notice that this will format result by replacing spaces in multi-syllable tokens with `_` and `_` with `~`.
+
+```
+$ tokenizer "toisongohanoi, tôi đăng ký trên thegioididong.vn" -k
+toisongohanoi   ,       tôi     đăng ký trên    the gioi        di dong vn
+
+$ tokenizer "toisongohanoi, tôi đăng ký trên thegioididong.vn" -t
+toisongohanoi   ,               tôi             đăng_ký         trên            the_gioi        di_dong vn
+```
+
 The usage of `vn_lang_tool` is pretty similar, you can see full list of options for both tools by using:
 
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+# Release 1.5
+
+## Major Features and Improvement
+
+* Before 1.5, punctuations and spaces are removed during normal tokenization, but are kept during tokenization for transformation, which is used internally by Coc Coc Search Engine. This update introduces option `keep_puncts` in `run_tokenize()` function, which can be used to keep punctuations (but not spaces and dots in segmented URLs) in normal tokenization.
+* New argument `-k` and `-t` are introduced in CLI, to toggle `keep_puncts` and `for_transformation` when running tokenizer.
+
+## Breaking changes
+
+* Before 1.5, `run_tokenize()` has a param named `dont_push_puncts`, which is used to prevent inclusion of punctuations in result when tokenizing for transformation. It was replaced by `keep_puncts`, which serves the same purpose but (1) can be used for both normal tokenization and tokenization for transformation and (2) positive parameter naming is a better practice. The default value of `keep_puncts` is equal to `for_transformation` - false for normal tokenization, true for transformation. So previous behaviour remains the same, but this will break old code if `run_tokenize()` was called with `for_transformation = true` and `dont_push_puncts = false`.
+
+## Other changes
+
+* Wrapper functions are added to C++ implementation, matching those in Java binding, for ease of use.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+coccoc-tokenizer (1.5) stable; urgency=medium
+
+  * added option to keep punctuations in normal tokenization
+  * added option to run tokenization for transformation in CLI
+  * added wrapper functions in C++ implementation, for ease of use
+  * breaking change: dont_push_puncts param in segment() now becomes keep_puncts, which is used to keep punctuations in both normal tokenization and tokenization for transformation
+
+ -- Tran Minh Hieu <hieutm@coccoc.com> Fri, 03 Jan 2020 10:50:00 +0700
+
 coccoc-tokenizer (1.4) stable; urgency=medium
 
   * added debian package for python bindings

--- a/java/src/java/Tokenizer.java
+++ b/java/src/java/Tokenizer.java
@@ -41,7 +41,7 @@ public class Tokenizer {
 		if (text == null) {
 			throw new IllegalArgumentException("text is null");
 		}
-		long resPointer = segmentPointer(text, for_transforming, keep_puncts, tokenizeOption);
+		long resPointer = segmentPointer(text, for_transforming, tokenizeOption, keep_puncts);
 
 		ArrayList<Token> res = new ArrayList<>();
 		// Positions from JNI implementation .cpp file
@@ -88,7 +88,7 @@ public class Tokenizer {
 	}
 
 	public ArrayList<Token> segment(String text, boolean for_transforming, int tokenizeOption) {
-		return segment(text, for_transforming, tokenizeOption, false);
+		return segment(text, for_transforming, tokenizeOption, for_transforming);
 	}
 
 	public ArrayList<Token> segment(String text, int tokenizeOption) {
@@ -105,6 +105,14 @@ public class Tokenizer {
 
 	public ArrayList<String> segmentToStringList(String text) {
 		return Token.toStringList(segment(text, false));
+	}
+
+	public ArrayList<Token> segmentKeepPuncts(String text) {
+		return segment(text, false, TOKENIZE_NORMAL, true);
+	}
+
+	public ArrayList<String> segmentKeepPunctsToStringList(String text) {
+		return Token.toStringList(segmentKeepPuncts(text));
 	}
 
 	public ArrayList<Token> segmentUrl(String text) {

--- a/java/src/java/Tokenizer.java
+++ b/java/src/java/Tokenizer.java
@@ -9,7 +9,7 @@ public class Tokenizer {
 	public static final int TOKENIZE_URL = 2;
 	public static final String dictPath = "/usr/share/tokenizer/dicts"; // TODO: don't hardcode this value
 
-	public native long segmentPointer(String text, boolean for_transforming, int tokenizeOption);
+	public native long segmentPointer(String text, boolean for_transforming, boolean keep_puncts, int tokenizeOption);
 	private native void freeMemory(long resPointer);
 	private native int initialize(String dictPath);
 
@@ -37,11 +37,11 @@ public class Tokenizer {
 		}
 	}
 
-	public ArrayList<Token> segment(String text, boolean for_transforming, int tokenizeOption) {
+	public ArrayList<Token> segment(String text, boolean for_transforming, boolean keep_puncts, int tokenizeOption) {
 		if (text == null) {
 			throw new IllegalArgumentException("text is null");
 		}
-		long resPointer = segmentPointer(text, for_transforming, tokenizeOption);
+		long resPointer = segmentPointer(text, for_transforming, keep_puncts, tokenizeOption);
 
 		ArrayList<Token> res = new ArrayList<>();
 		// Positions from JNI implementation .cpp file
@@ -85,6 +85,10 @@ public class Tokenizer {
 		}
 		freeMemory(resPointer);
 		return res;
+	}
+
+	public ArrayList<Token> segment(String text, boolean for_transforming, int tokenizeOption) {
+		return segment(text, for_transforming, false, tokenizeOption);
 	}
 
 	public ArrayList<Token> segment(String text, int tokenizeOption) {

--- a/java/src/java/Tokenizer.java
+++ b/java/src/java/Tokenizer.java
@@ -9,7 +9,7 @@ public class Tokenizer {
 	public static final int TOKENIZE_URL = 2;
 	public static final String dictPath = "/usr/share/tokenizer/dicts"; // TODO: don't hardcode this value
 
-	public native long segmentPointer(String text, boolean for_transforming, boolean keep_puncts, int tokenizeOption);
+	public native long segmentPointer(String text, boolean for_transforming, int tokenizeOption, boolean keep_puncts);
 	private native void freeMemory(long resPointer);
 	private native int initialize(String dictPath);
 
@@ -37,7 +37,7 @@ public class Tokenizer {
 		}
 	}
 
-	public ArrayList<Token> segment(String text, boolean for_transforming, boolean keep_puncts, int tokenizeOption) {
+	public ArrayList<Token> segment(String text, boolean for_transforming, int tokenizeOption, boolean keep_puncts) {
 		if (text == null) {
 			throw new IllegalArgumentException("text is null");
 		}
@@ -88,7 +88,7 @@ public class Tokenizer {
 	}
 
 	public ArrayList<Token> segment(String text, boolean for_transforming, int tokenizeOption) {
-		return segment(text, for_transforming, false, tokenizeOption);
+		return segment(text, for_transforming, tokenizeOption, false);
 	}
 
 	public ArrayList<Token> segment(String text, int tokenizeOption) {

--- a/java/src/jni/Tokenizer.cpp
+++ b/java/src/jni/Tokenizer.cpp
@@ -7,7 +7,7 @@
 #include "com_coccoc_Tokenizer.h"
 
 JNIEXPORT jlong JNICALL Java_com_coccoc_Tokenizer_segmentPointer(
-	JNIEnv *env, jobject obj, jstring jni_text, jboolean for_transforming, jint tokenize_option)
+	JNIEnv *env, jobject obj, jstring jni_text, jboolean for_transforming, jboolean keep_puncts, jint tokenize_option)
 {
 	// Use shared-memory instead of message-passing mechanism to transfer data to Java
 	// return a pointer to an array of pointers
@@ -26,7 +26,7 @@ JNIEXPORT jlong JNICALL Java_com_coccoc_Tokenizer_segmentPointer(
 	std::vector< int > *space_positions = new std::vector< int >();
 
 	Tokenizer::instance().handle_tokenization_request< Token >(
-		*text, *ranges, *space_positions, original_pos, for_transforming, tokenize_option);
+		*text, *ranges, *space_positions, original_pos, for_transforming, keep_puncts, tokenize_option);
 	for (size_t i = 0; i < ranges->size(); ++i)
 	{
 		ranges->at(i).original_start += original_pos[ranges->at(i).normalized_start];

--- a/java/src/jni/Tokenizer.cpp
+++ b/java/src/jni/Tokenizer.cpp
@@ -7,7 +7,7 @@
 #include "com_coccoc_Tokenizer.h"
 
 JNIEXPORT jlong JNICALL Java_com_coccoc_Tokenizer_segmentPointer(
-	JNIEnv *env, jobject obj, jstring jni_text, jboolean for_transforming, jboolean keep_puncts, jint tokenize_option)
+	JNIEnv *env, jobject obj, jstring jni_text, jboolean for_transforming, jint tokenize_option, jboolean keep_puncts)
 {
 	// Use shared-memory instead of message-passing mechanism to transfer data to Java
 	// return a pointer to an array of pointers
@@ -26,7 +26,7 @@ JNIEXPORT jlong JNICALL Java_com_coccoc_Tokenizer_segmentPointer(
 	std::vector< int > *space_positions = new std::vector< int >();
 
 	Tokenizer::instance().handle_tokenization_request< Token >(
-		*text, *ranges, *space_positions, original_pos, for_transforming, keep_puncts, tokenize_option);
+		*text, *ranges, *space_positions, original_pos, for_transforming, tokenize_option, keep_puncts);
 	for (size_t i = 0; i < ranges->size(); ++i)
 	{
 		ranges->at(i).original_start += original_pos[ranges->at(i).normalized_start];

--- a/tokenizer/tokenizer.hpp
+++ b/tokenizer/tokenizer.hpp
@@ -108,6 +108,17 @@ private:
 		return 0;
 	}
 
+	std::vector< std::string > to_string_list(const std::vector< FullToken > &tokens)
+	{
+		std::vector< std::string > res;
+		res.reserve(tokens.size());
+		for (auto it : tokens)
+		{
+			res.push_back(it.text);
+		}
+		return res;
+	}
+
 public:
 	Tokenizer()
 	{
@@ -1174,12 +1185,7 @@ public:
 		const std::string &text, bool for_transforming = false, int tokenize_option = TOKENIZE_NORMAL)
 	{
 		std::vector< FullToken > full_res = segment(text, for_transforming, tokenize_option);
-		std::vector< std::string > res;
-		for (auto it : full_res)
-		{
-			res.push_back(it.text);
-		}
-		return res;
+		return to_string_list(full_res);
 	}
 
 	// reimplement of segment_original for general purpose (python wrapping)
@@ -1222,6 +1228,42 @@ public:
 				  res.end());
 
 		return res;
+	}
+
+	// wrapper function matching Java binding, for ease of use
+	std::vector< FullToken > segment_keep_puncts(const std::string &original_text)
+	{
+		return segment(original_text, false, TOKENIZE_NORMAL, true);
+	}
+
+	// wrapper function matching Java binding, for ease of use
+	std::vector< std::string > segment_keep_puncts_to_string_list(const std::string &original_text)
+	{
+		return to_string_list(segment_keep_puncts(original_text));
+	}
+
+	// wrapper function matching Java binding, for ease of use
+	std::vector< FullToken > segment_url(const std::string &original_text)
+	{
+		return segment(original_text, false, TOKENIZE_URL);
+	}
+
+	// wrapper function matching Java binding, for ease of use
+	std::vector< std::string > segment_url_to_string_list(const std::string &original_text)
+	{
+		return to_string_list(segment_url(original_text));
+	}
+
+	// wrapper function matching Java binding, for ease of use
+	std::vector< FullToken > segment_for_transforming(const std::string &original_text)
+	{
+		return segment(original_text, true, TOKENIZE_NORMAL);
+	}
+
+	// wrapper function matching Java binding, for ease of use
+	std::vector< FullToken > segment_for_transforming(const std::string &original_text, int tokenize_option)
+	{
+		return segment(original_text, true, tokenize_option);
 	}
 };
 

--- a/tokenizer/tokenizer.hpp
+++ b/tokenizer/tokenizer.hpp
@@ -1113,7 +1113,7 @@ public:
 		std::vector< int > space_positions;
 
 		handle_tokenization_request< FullToken >(
-			text, res, space_positions, original_pos, false, false, tokenize_option);
+			text, res, space_positions, original_pos, false, tokenize_option);
 
 		for (int &pos : space_positions) pos = original_pos[pos];
 		space_positions.push_back(-1);
@@ -1193,7 +1193,7 @@ public:
 
 		// using for_transforming to keep punctuations
 		handle_tokenization_request< FullToken >(
-			text, res, space_positions, original_pos, /*for_transforming*/ true, false, tokenize_option);
+			text, res, space_positions, original_pos, /*for_transforming*/ true, tokenize_option);
 
 		for (int &pos : space_positions) pos = original_pos[pos];
 		space_positions.push_back(-1);

--- a/tokenizer/tokenizer.hpp
+++ b/tokenizer/tokenizer.hpp
@@ -684,7 +684,7 @@ public:
 				{
 					while (last_pos < temp.back().normalized_start)
 					{
-						if (!(!for_transforming && text[last_pos] == ' '))
+						if (for_transforming || text[last_pos] != ' ')
 						{
 							ranges.push_back({last_pos, last_pos + 1});
 							ranges.back().type =
@@ -711,7 +711,7 @@ public:
 			// PUNCTs at the end of the text
 			while (last_pos < length)
 			{
-				if (!(!for_transforming && text[last_pos] == ' '))
+				if (for_transforming || text[last_pos] != ' ')
 				{
 					ranges.push_back({last_pos, last_pos + 1});
 					ranges.back().type = text[last_pos] == ' ' ? T::SPACE : T::PUNCT;

--- a/utils/tokenizer.cpp
+++ b/utils/tokenizer.cpp
@@ -10,12 +10,16 @@
 struct tokenizer_option
 {
 	bool no_sticky;
+	bool keep_puncts;
+	bool for_transforming;
 	int tokenize_option;
 	int format;
 	const char *dict_path;
 
 	tokenizer_option()
 	    : no_sticky(false),
+		  keep_puncts(false),
+		  for_transforming(false),
 	      tokenize_option(Tokenizer::TOKENIZE_NORMAL),
 	      format(FORMAT_TSV),
 	      dict_path(DICT_PATH)
@@ -29,6 +33,8 @@ static struct option options[] = {
 	{ "no-sticky"    , no_argument      , NULL, 'n' },
 	{ "url"          , no_argument      , NULL, 'u' },
 	{ "host"         , no_argument      , NULL, 'h' },
+	{ "keep-puncts"  , no_argument      , NULL, 'k' },
+	{ "transform"    , no_argument      , NULL, 't' },
 	{ "format"       , required_argument, NULL, 'f' },
 	{ "dict-path"    , required_argument, NULL, 'd' },
 	{  NULL          , 0                , NULL,  0  }
@@ -45,6 +51,8 @@ int print_tokenizer_usage(int argc, char **argv)
 		"    -n, --no-sticky        : do not split sticky text\n"
 		"    -u, --url              : segment URL\n"
 		"    -h, --host             : segment HOST\n"
+		"    -k, --keep-puncts      : keep PUNCT tokens\n"
+		"    -t, --transform        : segment for transformation\n"
 		"    -f, --format <format>  : output format (tsv, original, verbose)\n"
 		"    -d, --dict-path <path> : dictionaries path, default is " DICT_PATH "\n"
 		"        --help             : show this message\n"
@@ -96,6 +104,12 @@ int tokenizer_getopt_parse(int argc, char **argv, tokenizer_option &opts)
 		case 'd':
 			opts.dict_path = optarg;
 			break;
+		case 'k':
+			opts.keep_puncts = true;
+			break;
+		case 't':
+			opts.for_transforming = true;
+			break;
 		default:
 			return -1;
 		}
@@ -122,7 +136,7 @@ int main(int argc, char **argv)
 	auto process = [&opts](const std::string &text)
 	{
 		std::vector< FullToken > res = opts.format != FORMAT_ORIGINAL ?
-			Tokenizer::instance().segment(text, false, opts.tokenize_option) :
+			Tokenizer::instance().segment(text, opts.for_transforming, opts.keep_puncts, opts.tokenize_option) :
 			Tokenizer::instance().segment_original(text, opts.tokenize_option);
 
 		if (opts.format == FORMAT_ORIGINAL)

--- a/utils/tokenizer.cpp
+++ b/utils/tokenizer.cpp
@@ -69,7 +69,7 @@ int print_tokenizer_usage(int argc, char **argv)
 int tokenizer_getopt_parse(int argc, char **argv, tokenizer_option &opts)
 {
 	int option_code;
-	while (~(option_code = getopt_long(argc, argv, "nuhf:d:", options, NULL)))
+	while (~(option_code = getopt_long(argc, argv, "nuhf:d:kt", options, NULL)))
 	{
 		switch (option_code)
 		{

--- a/utils/tokenizer.cpp
+++ b/utils/tokenizer.cpp
@@ -10,7 +10,7 @@
 struct tokenizer_option
 {
 	bool no_sticky;
-	bool keep_puncts;
+	int keep_puncts;
 	bool for_transforming;
 	int tokenize_option;
 	int format;
@@ -18,7 +18,7 @@ struct tokenizer_option
 
 	tokenizer_option()
 	    : no_sticky(false),
-		  keep_puncts(false),
+		  keep_puncts(-1),
 		  for_transforming(false),
 	      tokenize_option(Tokenizer::TOKENIZE_NORMAL),
 	      format(FORMAT_TSV),
@@ -135,8 +135,11 @@ int main(int argc, char **argv)
 
 	auto process = [&opts](const std::string &text)
 	{
+		if (opts.keep_puncts == -1) {
+			opts.keep_puncts = opts.for_transforming;
+		}
 		std::vector< FullToken > res = opts.format != FORMAT_ORIGINAL ?
-			Tokenizer::instance().segment(text, opts.for_transforming, opts.keep_puncts, opts.tokenize_option) :
+			Tokenizer::instance().segment(text, opts.for_transforming, opts.tokenize_option, opts.keep_puncts) :
 			Tokenizer::instance().segment_original(text, opts.tokenize_option);
 
 		if (opts.format == FORMAT_ORIGINAL)


### PR DESCRIPTION
We need punctuation in tokenization result, to handle special tokens such as `.`, `@` or emoji.

Since `dont_push_puncts` in `run_tokenizer()` function is always set to `false`, and its name collides with new option `keep_puncts`, it was removed.

On console application, `keep_puncts` can be set to `true` with option `--k`. Tokenization for transformation can be turned on with option `--t`.